### PR TITLE
Added dependency for electron-packager which fixes a bug in the installation process

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "electron": "^13.1.7",
+    "electron-packager": "^17.1.2",
     "electron-alert": "^0.1.16",
     "electron-open-link-in-browser": "^1.0.2",
     "league-connector": "^1.0.6",


### PR DESCRIPTION
Hello!

My friend was trying to install your software but couldn't do it because electron-packager was missing.
The error occured when running "npm run package-win".

Adding electron-packager to the dependency list and following the readme (running npm install) solved it.